### PR TITLE
Fixes query detection for INSERT INTO statements

### DIFF
--- a/lib/clickhousex/query.ex
+++ b/lib/clickhousex/query.ex
@@ -88,8 +88,8 @@ defimpl DBConnection.Query, for: Clickhousex.Query do
   defp query_type(statement) do
     cond do
       Regex.match?(@create_query_regex, statement) -> :create
-      Regex.match?(@select_query_regex, statement) -> :select
       Regex.match?(@insert_query_regex, statement) -> :insert
+      Regex.match?(@select_query_regex, statement) -> :select
       Regex.match?(@alter_query_regex, statement) -> :alter
       true -> :update
     end


### PR DESCRIPTION
Currently `INSERT INTO table SELECT ...` is detected incorrectly as a `SELECT` statement, this causes failures as the adapter attempts to parse the response as if it's a `SELECT` response when there are non (since it's an `INSERT INTO` query)