### PR TITLE
prevent escaping "

### DIFF
--- a/lib/clickhousex/codec/values.ex
+++ b/lib/clickhousex/codec/values.ex
@@ -105,7 +105,6 @@ defmodule Clickhousex.Codec.Values do
     |> String.replace("_", "\_")
     |> String.replace("'", "''")
     |> String.replace("%", "\%")
-    |> String.replace(~s("), ~s(\\"))
     |> String.replace("\\", "\\\\")
   end
 end


### PR DESCRIPTION
Escaping `"` will cause an issue in storing encoded json fields, we need to stop this to be able to store encoded json in string columns.