### PR TITLE
Tweaking the interpretation of question-mark literals

### DIFF
--- a/lib/clickhousex/query.ex
+++ b/lib/clickhousex/query.ex
@@ -49,7 +49,7 @@ defimpl DBConnection.Query, for: Clickhousex.Query do
       query
       | type: query_type,
         param_count: param_count,
-        statement: String.replace(@escaped_question_mark_literal, "?")
+        statement: String.replace(statement, @escaped_question_mark_literal, "?")
     }
   end
 


### PR DESCRIPTION
### Issue Description
- The question mark "?" is usually used as an anonymous **placeholder** for parameters bound to the prepared statement. It comes handy as a way to avoid SQL injection. 
  - The question mark (?) is the only placeholder character that the SQL standard defines. Question marks are placeholders for **positional parameters**, e.g. ```SQL
  SELECT * FROM exclusions WHERE (e0.category IN (?,?)) ["user_id", "company_id"]```
- Initially, the library treated every question mark (?) in the query as a placeholder for a parameter, even if it's part of string contained within single/double quotes. Naively, the code-block that calculates the parameters count that should be bind to the query was count the number of occurrences of (?) in the statement/query (raw SQL string)
- This PR tweaks the [**Clickhousex.Query.parse/2**](https://github.com/Userpilot/clickhousex/blob/master/lib/clickhousex/query.ex#L37-L46) to first remove all question marks that are backslash-escaped, as those are to be treated as question mark **literal**, **NOT** as placeholders for positional arguments.
- Before forwarding the %Query{} object, at the end of parse function, the `statement` is sanitized by actively replacing all **backslash-escaped** question mark literals with only the question mark itself.

**Partially Fixes**: https://userpilot.atlassian.net/browse/NXTAPP-2143


**Error Log**: https://my.papertrailapp.com/systems/appex-prod-std-us/events?q=the+number+of+&focus=1442880723106279437&selected=1442880723106279437
```
2022-03-22T10:59:54.000Z appex-prod-std-us appex-prod-std-us  [error] Task #PID<0.17363.406> started from #PID<0.9259.406> terminating ** (ArgumentError) The number of parameters does not correspond to the number of question marks!     (clickhousex 0.4.0) lib/clickhousex/codec/values.ex:21: Clickhousex.Codec.Values.encode/3     (clickhousex 0.4.0) lib/clickhousex/query.ex:63: DBConnection.Query.Clickhousex.Query.encode/3     (db_connection 2.2.2) lib/db_connection.ex:1148: DBConnection.encode/5     (db_connection 2.2.2) lib/db_connection.ex:1246: DBConnection.run_prepare_execute/5     (db_connection 2.2.2) lib/db_connection.ex:1342: DBConnection.run/6     (db_connection 2.2.2) lib/db_connection.ex:539: DBConnection.parsed_prepare_execute/5     (db_connection 2.2.2) lib/db_connection.ex:532: DBConnection.prepare_execute/4     (clickhousex 0.4.0) lib/clickhousex.ex:59: Clickhousex.query/4 Function: &Core.Analytex.Common.ParallelQuery.perform/1     Args: [%Core.Analytex.Common.ParallelQuery{fun: &Core.Analytex.Checklist.Queries.dismissed_time_series/3, params: ["15sq4i9", [steps: "arrayJoin(arrayDistinct(arrayMap(x -> toDate(toDate(x, 'Canada/Atlantic')), range(toUInt32(DATE_SUB(MONTH, 1, toStartOfMonth(now(), 'Canada/Atlantic'))), toUInt32(toStartOfMonth(now(), 'Canada/Atlantic'))))))", period: "BETWEEN DATE_SUB(MONTH, 1, toStartOfMonth(now(), 'Canada/Atlantic')) AND DATE_SUB(DAY, 1, toStartOfMonth(now(), 'Canada/Atlantic'))", filters: "AND user_id in (SELECT DISTINCT(user_id) from users_wide where app_token = '15sq4i9' and user_id in ((  SELECT\n    DISTINCT(user_id)\n  FROM\n    users_wide\n  WHERE\n    app_token = '15sq4i9'\n    AND (((((lowerUTF8(metadata.value[indexOf(metadata.key, '_userpilotForm_Do_you_currently_use_an_EMR,_EHR_or_practice_management_solution_that_is_different_from_this_virtual_care_platform?_If_so,_which_one?')]) != '' OR lowerUTF8(metadata.value[indexOf(metadata.key, '_userpilotForm_What_is_the_main_benefit_you_or_your_organization_realizes_from_using_a_virtual_care_platform_like_this_one?')]) != '') OR lowerUTF8(metadata.value[indexOf(metadata.key, '_userpilotForm_What_is_the_number_one_metric_that_is_important_for_you_in_your_role?')]) != '') OR lowerUTF8(metadata.value[indexOf(metadata.key, '_userpilotForm_Who_at_your_organization_do_you_think_benefits_most_from_using_a_virtual_care_platform_like_this_one?')]) != '') OR lowerUTF8(metadata.value[indexOf(metadata.key, '_userpilotForm_What_other_tools_or_platforms_do_you_use_every_day_(i.e._EMR/EHR,_CRM,_forms/file_management_software,_etc)?')]) != '') OR lowerUTF8(metadata.value[indexOf(metadata.key, '_userpilotForm_How_can_we_improve_this_virtual_care_platform_for_you?')]) != '')\n)))", prev_period: "BETWEEN DATE_SUB(MONTH, 1, toStartOfMonth(now(), 'Canada/Atlantic')) AND DATE_SUB(DAY, 1, toStartOfMonth(now(), 'Canada/Atlantic'))", agg_fun: "toDate", prev_steps: "arrayJoin(arrayDistinct(arrayMap(x -> toDate(toDate(x, 'Canada/Atlantic')), range(toUInt32(DATE_SUB(MONTH, 1, toStartOfMonth(now(), 'Canada/Atlantic'))), toUInt32(toStartOfMonth(now(), 'Canada/Atlantic'))))))", timezone: "Canada/Atlantic", compare: "true", exclusions: "1"], :cumulative], select_mode: :all, task_type: :analytex}]
```