### PR TITLE
(feat) Send zero-param SELECT queries in POST body to overcome Request URI size/length limitations

### DIFF
--- a/lib/clickhousex/query.ex
+++ b/lib/clickhousex/query.ex
@@ -66,6 +66,20 @@ defimpl DBConnection.Query, for: Clickhousex.Query do
     |> HTTPRequest.with_post_data(encoded_params)
   end
 
+  @doc """
+    Special handling for zero-param SELECT queries (i.e. raw queries) indicated by
+    `type: :select` and `param_count: 0` where the encoded query statement is to placed
+    inside of the POST Body instead of placing it on the query string to overcome existing issues
+    where the encoded query is Too Large to fit into the query params of the Request's URI, which was observed
+    frequently on our error logging system under the message: `Request-URI Too Large`.
+  """
+  def encode(%Clickhousex.Query{type: :select, param_count: 0} = query, params, _opts) do
+    {query_statement, _post_body_part} = do_parse(query)
+    encoded_query_statement = @codec.encode(query, query_statement, params)
+
+    HTTPRequest.with_post_data(HTTPRequest.new(), encoded_query_statement)
+  end
+
   def encode(query, params, _opts) do
     {query_part, _post_body_part} = do_parse(query)
     encoded_params = @codec.encode(query, query_part, params)


### PR DESCRIPTION
### Dev. Notes
- Change of behavior is ONLY carried out for zero-param queries, indicated by `param_count` field on the ClickHousex.Query struct definition.
  - Parametrized _ClickHouse_ SELECT queries, generated using Ecto,  will continue to send the query as a **URL parameter**.
  - Usually, _Appex_ analytical APIs are written in raw SQL and therefore are not parametrized (`param_count` = 0)
- `X-ClickHouse-Database` request header was used to specify the default/active database
https://clickhouse.com/docs/en/interfaces/http/#default-database
- `X-ClickHouse-Format` header was used to specify `JSONCompact` as the response format for SELECT queries. Originally, the format was appended to the POST body while the query reside in the query string.
  > You use the FORMAT clause of the query to request any other format.
Also, you can use the ‘default_format’ URL parameter or the ‘X-ClickHouse-Format’ header to specify a default format other than TabSeparated.

### Related Error Log(s) 
https://my.papertrailapp.com/systems/appex-prod-std-us/events?q=Request-URI+&focus=1484751893950509092&selected=1484751893950509092
```
2022-07-16T00:00:59.000Z appex-prod-std-us appex-prod-std-us  [error] #PID<0.25309.1617> running HttpWeb.Endpoint (connection #PID<0.14283.1582>, stream id 1) terminated Server: appex.userpilot.io:80 (http) Request: POST /api/v1/analytics/48dt39m5/users ** (exit) an exception was raised:     ** (Protocol.UndefinedError) protocol Enumerable not implemented for {:error, %Clickhousex.Error{code: :unknown, constraint_violations: [], message: "<html>\r\n<head><title>414 Request-URI Too Large</title></head>\r\n<body>\r\n<center><h1>414 Request-URI Too Large</h1></center>\r\n</body>\r\n</html>\r\n"}} of type Tuple. This protocol is implemented for the following type(s): DBConnection.PrepareStream, DBConnection.Stream, Date.Range, Ecto.Adapters.SQL.Stream, File.Stream, Function, GenEvent.Stream, HashDict, HashSet, IO.Stream, List, Map, MapSet, Range, Stream, Timex.Interval         (elixir 1.13.4) lib/enum.ex:1: Enumerable.impl_for!/1         (elixir 1.13.4) lib/enum.ex:143: Enumerable.reduce/3         (elixir 1.13.4) lib/enum.ex:4144: Enum.map/2         (core 22.27.9+4cdbf540) lib/core/analytex/paginator/paginator.ex:29: Core.Analytex.Paginator.finalize_page_response/2         (core 22.27.9+4cdbf540) lib/core/analytex/users/users.ex:61: Core.Analytex.Users.actions/3         (http 22.27.9+4cdbf540) lib/http_web/controllers/analytics/v1/user_controller.ex:25: HttpWeb.Analytics.V1.UserController.index/2         (http 22.27.9+4cdbf540) lib/http_web/controllers/analytics/v1/user_controller.ex:1: HttpWeb.Analytics.V1.UserController.action/2         (http 22.27.9+4cdbf540) lib/http_web/controllers/analytics/v1/user_controller.ex:1: HttpWeb.Analytics.V1.UserController.phoenix_controller_pipeline/2
```