### PR TITLE
Properly recognize query type

### DIFF
--- a/lib/clickhousex/query.ex
+++ b/lib/clickhousex/query.ex
@@ -111,12 +111,14 @@ defimpl DBConnection.Query, for: Clickhousex.Query do
   defp query_type(statement) do
     cond do
       statement
-      |> normalize_query_statement()
+      |> String.trim_leading()
+      |> String.downcase()
       |> String.starts_with?(String.downcase(@create_query_keyword)) ->
         :create
 
       statement
-      |> normalize_query_statement()
+      |> String.trim_leading()
+      |> String.downcase()
       |> String.starts_with?(String.downcase(@insert_query_keyword)) ->
         :insert
 
@@ -130,12 +132,6 @@ defimpl DBConnection.Query, for: Clickhousex.Query do
         :update
     end
   end
-
-  defp normalize_query_statement(statement),
-    do:
-      statement
-      |> String.trim_leading()
-      |> String.downcase()
 end
 
 defimpl String.Chars, for: Clickhousex.Query do

--- a/lib/clickhousex/query.ex
+++ b/lib/clickhousex/query.ex
@@ -110,27 +110,21 @@ defimpl DBConnection.Query, for: Clickhousex.Query do
 
   defp query_type(statement) do
     cond do
-      statement
-      |> String.trim_leading()
-      |> String.downcase()
-      |> String.starts_with?(String.downcase(@create_query_keyword)) ->
-        :create
-
-      statement
-      |> String.trim_leading()
-      |> String.downcase()
-      |> String.starts_with?(String.downcase(@insert_query_keyword)) ->
-        :insert
-
-      Regex.match?(@select_query_regex, statement) ->
-        :select
-
-      Regex.match?(@alter_query_regex, statement) ->
-        :alter
-
-      true ->
-        :update
+      starts_with_keyword?(statement, @create_query_keyword) -> :create
+      starts_with_keyword?(statement, @insert_query_keyword) -> :insert
+      Regex.match?(@select_query_regex, statement) -> :select
+      Regex.match?(@alter_query_regex, statement) -> :alter
+      true -> :update
     end
+  end
+
+  defp starts_with_keyword?(statement, keyword) do
+    downcased_keyword = String.downcase(keyword)
+
+    statement
+    |> String.trim_leading()
+    |> String.downcase()
+    |> String.starts_with?(downcased_keyword)
   end
 end
 


### PR DESCRIPTION
- We have experienced a case where SELECT queries having **case-insensitive** CREATE/INSERT as Strings will be mistakenly recognized as CREATE/INSERT statements.
  - We have hit a case where a customer on Production tried filtering users based on a **Trackable Event** w/ the event name being "Playlist Create" which lead to the Adapter incorrectly figuring the query type as a CREATE statement while it's actually a SELECT.
```SQL
SELECT DISTINCT(user_id)
FROM users_wide
WHERE app_token = 'NX-80ne98v4'
  AND has(trackable_events, 'playlist create')
  AND toStartOfYear(last_seen, 'Canada/Atlantic') BETWEEN toStartOfYear(now(), 'Canada/Atlantic') AND now('Canada/Atlantic')
```
  - This PR changes the way of figuring out the query type to the following procedure:
    - Trim all leading Unicode whitespace characters off the query statement.
    - Convert the query statement into it's down-cased (i.e. lowercased) form
    - Check if the statement starts with the INSERT/CREATE keywords (in lowercase).
    -  Otherwise, if the statement matches the _SELECT_ statement's Regex then its a `:select` type and if it matches the _ALTER_ statement's Regex then it's to be considered as `:alter`

- [Papertrail's Error Log](https://my.papertrailapp.com/systems/appex-prod-std-us/events?focus=1491747060351905813&selected=1491747060351905813)

> ```2022-08-04T07:17:17.000Z appex-prod-std-us appex-prod-std-us  [appex.userpilot.io] [error] Task #PID<0.19805.195> started from #PID<0.19997.195> terminating ** (Protocol.UndefinedError) protocol Enumerable not implemented for nil of type Atom. This protocol is implemented for the following type(s): DBConnection.PrepareStream, DBConnection.Stream, Date.Range, Ecto.Adapters.SQL.Stream, File.Stream, Function, GenEvent.Stream, HashDict, HashSet, IO.Stream, List, Map, MapSet, Range, Stream, Timex.Interval     (elixir 1.13.4) lib/enum.ex:1: Enumerable.impl_for!/1     (elixir 1.13.4) lib/enum.ex:143: Enumerable.reduce/3     (elixir 1.13.4) lib/enum.ex:4144: Enum.map/2     (elixir 1.13.4) lib/task/supervised.ex:89: Task.Supervised.invoke_mfa/2     (elixir 1.13.4) lib/task/supervised.ex:34: Task.Supervised.reply/4     (stdlib 3.17.2) proc_lib.erl:226: :proc_lib.init_p_do_apply/3 Function: &Core.Analytex.Common.ParallelQuery.perform/1     Args: [%Core.Analytex.Common.ParallelQuery{fun: &Core.Analytex.Users.Queries.list_users_per_segment/2, params: ["23ti96h9", [columns: "user_agent AS `browser`,\nbrowser_language AS `browser_language`,\ncountry_code AS `country`,\ndevice_type AS `device_type`,\nfirst_seen AS `first_seen`,\nhostname AS `host name`,\nlast_seen AS `last_seen`,\nmetadata.key AS `metadata_keys`,\nmetadata.value AS `metadata_values`,\noperating_system AS `os`,\nuser_id AS `user_id`,\nscreen_height AS `viewport_height`,\nscreen_width AS `viewport_width`,\nsessions AS `web_sessions`", exclusions: "1", filters: "AND user_id in (\n        SELECT\n    DISTINCT(user_id)\n  FROM\n    users_wide\n  WHERE\n    app_token = '23ti96h9'\n    AND (has(trackable_events, 'Create Project') AND has(trackable_features, '4'))\n\n        AND toStartOfWeek(last_seen, 1, 'Europe/Brussels') BETWEEN toStartOfWeek(now(), 1, 'Europe/Brussels') AND now('Europe/Brussels')\n    )", search_filters: "", for_users: "", for_company: "", timezone: "Europe/Brussels", agg_fun: "toStartOfWeek", period: "BETWEEN toStartOfWeek(now(), 1, 'Europe/Brussels') AND now('Europe/Brussels')", cursor_specs: %{limit: 51, order_by: "last_seen DESC, user_id DESC", where: nil}]], select_mode: :all, task_type: :analytex}]```