### PR TITLE
[Feat] Support decoding `SimpleAggregateFunction(agg, Type)` fields in JSON/RowBinary Codec

### DIFF
--- a/lib/clickhousex/codec/json.ex
+++ b/lib/clickhousex/codec/json.ex
@@ -37,6 +37,17 @@ defmodule Clickhousex.Codec.JSON do
     nil
   end
 
+  defp to_native(<<"SimpleAggregateFunction(", specs::binary>>, value) do
+    [_aggregate_function, underlying_type] =
+      specs
+      |> String.replace_suffix(")", "")
+      |> String.split(",", parts: 2)
+
+    underlying_type
+    |> String.trim_leading()
+    |> to_native(value)
+  end
+
   defp to_native(<<"Nullable(", type::binary>>, value) do
     type = String.replace_suffix(type, ")", "")
     to_native(type, value)

--- a/lib/clickhousex/codec/json.ex
+++ b/lib/clickhousex/codec/json.ex
@@ -37,15 +37,13 @@ defmodule Clickhousex.Codec.JSON do
     nil
   end
 
-  defp to_native(<<"SimpleAggregateFunction(", specs::binary>>, value) do
+  defp to_native(<<"SimpleAggregateFunction(", args::binary>>, value) do
     [_aggregate_function, underlying_type] =
-      specs
+      args
       |> String.replace_suffix(")", "")
-      |> String.split(",", parts: 2)
+      |> String.split(~r/,\s*/, parts: 2)
 
-    underlying_type
-    |> String.trim_leading()
-    |> to_native(value)
+    to_native(underlying_type, value)
   end
 
   defp to_native(<<"Nullable(", type::binary>>, value) do

--- a/lib/clickhousex/codec/row_binary.ex
+++ b/lib/clickhousex/codec/row_binary.ex
@@ -96,6 +96,15 @@ defmodule Clickhousex.Codec.RowBinary do
     decode_row(rest, types, [value | row])
   end
 
+  defp to_type(<<"SimpleAggregateFunction(", args::binary>>) do
+    [_aggregate_function, underlying_type] =
+      args
+      |> String.replace_suffix(")", "")
+      |> String.split(~r/,\s*/, parts: 2)
+
+    to_type(underlying_type)
+  end
+
   defp to_type(<<"Nullable(", type::binary>>) do
     rest_type =
       type

--- a/test/clickhousex/query_test.exs
+++ b/test/clickhousex/query_test.exs
@@ -98,7 +98,7 @@ defmodule Clickhousex.QueryTest do
                ]
              )
 
-    assert {:ok, %Result{columns: column_names, rows: [row]}} = select_all(ctx)
+    assert {:ok, %Result{columns: _column_names, rows: [row]}} = select_all(ctx)
 
     naive_datetime =
       datetime
@@ -136,7 +136,8 @@ defmodule Clickhousex.QueryTest do
     """
 
     now_date = Date.utc_today()
-    now_datetime = DateTime.utc_now()
+    now_datetime = DateTime.utc_now() |> DateTime.truncate(:second)
+    now_naive_datetime = DateTime.to_naive(now_datetime)
 
     assert {:ok, %Result{}} = schema(ctx, create_statement)
 
@@ -155,6 +156,9 @@ defmodule Clickhousex.QueryTest do
              )
 
     assert {:ok, %Result{rows: [row_1, row_2]}} = select_all(ctx)
+
+    assert row_1 == [1, 2, "hi", now_date, now_naive_datetime]
+    assert row_2 == [2, nil, nil, nil, nil]
   end
 
   test "arrays", ctx do


### PR DESCRIPTION
### Description
- Support decoding [SimpleAggregateFunction(name, types_of_arguments)](https://clickhouse.com/docs/en/sql-reference/data-types/simpleaggregatefunction/) in JSON/RowBinary codes.

### Examples
```Elixir
iex(13)> Clickhousex.Codec.JSON.to_native "SimpleAggregateFunction(min, DateTime64(6, 'Etc/UTC'))", "2022-07-23 16:04:51.806413"
~N[2022-07-23 16:04:51.806413]
iex(14)> Clickhousex.Codec.JSON.to_native "SimpleAggregateFunction(max, DateTime64(6, 'Etc/UTC'))", "2022-08-07 14:10:42.997835"
~N[2022-08-07 14:10:42.997835]
iex(15)> Clickhousex.Codec.JSON.to_native "SimpleAggregateFunction(any, Array(UInt8))", [15, 25, 30, 35]                        
[15, 25, 30, 35]
iex(16)> Clickhousex.Codec.JSON.to_native "SimpleAggregateFunction(any, Array(Float32))", [1, 2, 3, 4]     
[1.0, 2.0, 3.0, 4.0]
iex(17)> Clickhousex.Codec.JSON.to_native "SimpleAggregateFunction(anyLast, Nullable(String))", nil          
nil
iex(18)> Clickhousex.Codec.JSON.to_native "SimpleAggregateFunction(anyLast, Tuple(String, String, UInt32, Nullable(String)))", ["41po60v3", "backend_user_9", 10, nil]
{"41po60v3", "backend_user_9", 10, nil}
iex(19)> Clickhousex.Codec.JSON.to_native "SimpleAggregateFunction(min, Date)", "2022-08-07"                                                                          
~D[2022-08-07]
```