### PR TITLE
Fix replacing question mark literal `?` inside of query statement 

### DIFF
--- a/lib/clickhousex/query.ex
+++ b/lib/clickhousex/query.ex
@@ -49,8 +49,8 @@ defimpl DBConnection.Query, for: Clickhousex.Query do
     %{
       query
       | type: query_type,
-        param_count: param_count,
-        statement: String.replace(statement, @escaped_question_mark_literal, "?")
+        statement: statement,
+        param_count: param_count
     }
   end
 


### PR DESCRIPTION
### Description
- We should replace escaped question mark literals inside of the query statement with an empty string, **ONLY** when counting the params/bindings of the query, so that question mark literals within Strings don't be interpreted as a placeholder for a parameter binding.
- We don't need to revert the escaped question mark literal to an `?` and it should remain escaped when sending query to ClickHouse, or else the query's result will be incorrect, as the question mark that's matched to be in a String value **should remain escaped**.