### PR TITLE
Adopt async queries

### DIFF
--- a/lib/clickhousex/http_client.ex
+++ b/lib/clickhousex/http_client.ex
@@ -12,8 +12,9 @@ defmodule Clickhousex.HTTPClient do
   end
 
   def send(query, request, base_address, timeout, username, password, database, opts \\ []) do
-    async_opts = Keyword.take(opts, [:async, :async_callback])
-
+    async = Keyword.get(opts, :async, false)
+    async_callback = Keyword.get(opts, :async_callback)
+    async_opts = [async: async, async_callback: async_callback]
 
     local_opts = [
       hackney: [basic_auth: {username, password}],

--- a/lib/clickhousex/http_client.ex
+++ b/lib/clickhousex/http_client.ex
@@ -7,13 +7,42 @@ defmodule Clickhousex.HTTPClient do
 
   @req_headers [{"Content-Type", "text/plain"}]
 
-  def send(query, request, base_address, timeout, nil, _password, database) do
-    send_p(query, request, base_address, database, timeout: timeout, recv_timeout: timeout)
+  defp do_post_http(base_address, post_body, req_headers, http_opts, async_opts) do
+    case async_opts[:async] do
+      false ->
+        HTTPoison.post(base_address, post_body, req_headers, http_opts)
+
+      true ->
+        spawn(fn ->
+          with {:ok, %{status_code: 200, body: _body}} = response <-
+                 HTTPoison.post(base_address, post_body, req_headers, http_opts) do
+            maybe_notify(:ok, async_opts[:async_callback], response)
+          else
+            {:error, %{reason: _reason}} = response -> maybe_notify(:error, async_opts[:async_fallback], response)
+          end
+
+        end)
+        {:async, :executing}
+    end
   end
 
-  def send(query, request, base_address, timeout, username, password, database) do
-    opts = [hackney: [basic_auth: {username, password}], timeout: timeout, recv_timeout: timeout]
-    send_p(query, request, base_address, database, opts)
+  def send(query, request, base_address, timeout, nil, _password, database, _opts) do
+    send_p(query, request, base_address, database, [timeout: timeout, recv_timeout: timeout], [])
+  end
+
+  def send(query, request, base_address, timeout, username, password, database, opts) do
+    async = Keyword.get(opts, :async, false)
+    async_callback = Keyword.get(opts, :async_callback)
+    async_fallback = Keyword.get(opts, :async_fallback)
+    async_opts = [async: async, async_callback: async_callback, async_fallback: async_fallback]
+
+    local_opts = [
+      hackney: [basic_auth: {username, password}],
+      timeout: timeout,
+      recv_timeout: timeout
+    ]
+
+    send_p(query, request, base_address, database, local_opts, async_opts)
   end
 
   defp send_p(
@@ -21,28 +50,31 @@ defmodule Clickhousex.HTTPClient do
          %HTTPRequest{} = request,
          base_address,
          database,
-         opts
-       ) when query_type in [:select, :alter]  do
+         opts,
+         async_opts
+       )
+       when query_type in [:select, :alter] do
     command = parse_command(query)
 
     http_headers =
       build_http_post_headers(database: database, response_format: @codec.response_format())
 
     with {:ok, %{status_code: 200, body: body}} <-
-           HTTPoison.post(base_address, request.post_data, http_headers, opts),
+           do_post_http(base_address, request.post_data, http_headers, opts, async_opts),
          {:command, :selected} <- {:command, command},
          {:ok, %{column_names: column_names, rows: rows}} <- @codec.decode(body) do
       {:ok, command, column_names, rows}
     else
       {:command, :created} -> {:ok, :created}
       {:command, :updated} -> {:ok, :updated, 1}
+      {:async, :executing} -> {:ok, :created}
       {:ok, response} -> {:error, response.body}
       {:error, %{reason: reason}} -> {:error, reason}
       {:error, error} -> {:error, error}
     end
   end
 
-  defp send_p(query, request, base_address, database, opts) do
+  defp send_p(query, request, base_address, database, opts, async_opts) do
     command = parse_command(query)
 
     post_body = maybe_append_format(query, request)
@@ -54,13 +86,14 @@ defmodule Clickhousex.HTTPClient do
       })
 
     with {:ok, %{status_code: 200, body: body}} <-
-           HTTPoison.post(base_address, post_body, @req_headers, http_opts),
+           do_post_http(base_address, post_body, @req_headers, http_opts, async_opts),
          {:command, :selected} <- {:command, command},
          {:ok, %{column_names: column_names, rows: rows}} <- @codec.decode(body) do
       {:ok, command, column_names, rows}
     else
       {:command, :created} -> {:ok, :created}
       {:command, :updated} -> {:ok, :updated, 1}
+      {:async, :executing} -> {:ok, :created}
       {:ok, response} -> {:error, response.body}
       {:error, %{reason: reason}} -> {:error, reason}
       {:error, error} -> {:error, error}
@@ -87,4 +120,9 @@ defmodule Clickhousex.HTTPClient do
       "X-ClickHouse-Format" => response_format
     })
   end
+
+  defp maybe_notify(:ok, nil, _resp), do: :noop
+  defp maybe_notify(:ok, async_callback, resp), do: async_callback.(resp)
+  defp maybe_notify(:error, nil, _resp), do: :noop
+  defp maybe_notify(:error, async_fallback, resp), do: async_fallback.(resp)
 end

--- a/lib/clickhousex/http_client.ex
+++ b/lib/clickhousex/http_client.ex
@@ -7,12 +7,10 @@ defmodule Clickhousex.HTTPClient do
 
   @req_headers [{"Content-Type", "text/plain"}]
 
-  def send(query, request, base_address, timeout, nil, _password, database, _opts) do
-    send_p(query, request, base_address, database, [timeout: timeout, recv_timeout: timeout], [])
-  end
-
-  def send(query, request, base_address, timeout, username, password, database, opts \\ []) do
+  def send(query, request, base_address, timeout, username, password, database, opts \\ [])
+  def send(query, request, base_address, timeout, username, password, database, opts) do
     async_opts = Keyword.take(opts, [:async, :async_callback])
+
     local_opts = [
       hackney: [basic_auth: {username, password}],
       timeout: timeout,
@@ -20,6 +18,10 @@ defmodule Clickhousex.HTTPClient do
     ]
 
     send_p(query, request, base_address, database, local_opts, async_opts)
+  end
+
+  def send(query, request, base_address, timeout, nil, _password, database, _opts) do
+    send_p(query, request, base_address, database, [timeout: timeout, recv_timeout: timeout], [])
   end
 
   defp send_p(

--- a/lib/clickhousex/http_client.ex
+++ b/lib/clickhousex/http_client.ex
@@ -12,10 +12,7 @@ defmodule Clickhousex.HTTPClient do
   end
 
   def send(query, request, base_address, timeout, username, password, database, opts \\ []) do
-    async = Keyword.get(opts, :async, false)
-    async_callback = Keyword.get(opts, :async_callback)
-    async_opts = [async: async, async_callback: async_callback]
-
+    async_opts = Keyword.take(opts, [:async, :async_callback])
     local_opts = [
       hackney: [basic_auth: {username, password}],
       timeout: timeout,
@@ -81,10 +78,10 @@ defmodule Clickhousex.HTTPClient do
   end
 
   defp do_post_http(base_address, post_body, req_headers, http_opts, async_opts) do
-    case async_opts[:async] do
+    async_flag = Keyword.get(async_opts, :async, false)
+    case async_flag do
       false ->
         HTTPoison.post(base_address, post_body, req_headers, http_opts)
-
       true ->
         spawn(fn ->
           response  = HTTPoison.post(base_address, post_body, req_headers, http_opts)

--- a/lib/clickhousex/http_client.ex
+++ b/lib/clickhousex/http_client.ex
@@ -7,20 +7,6 @@ defmodule Clickhousex.HTTPClient do
 
   @req_headers [{"Content-Type", "text/plain"}]
 
-  defp do_post_http(base_address, post_body, req_headers, http_opts, async_opts) do
-    case async_opts[:async] do
-      false ->
-        HTTPoison.post(base_address, post_body, req_headers, http_opts)
-
-      true ->
-        spawn(fn ->
-          response  = HTTPoison.post(base_address, post_body, req_headers, http_opts)
-          maybe_notify(async_opts[:async_callback], response)
-        end)
-        {:async, :executing}
-    end
-  end
-
   def send(query, request, base_address, timeout, nil, _password, database, _opts) do
     send_p(query, request, base_address, database, [timeout: timeout, recv_timeout: timeout], [])
   end
@@ -91,6 +77,20 @@ defmodule Clickhousex.HTTPClient do
       {:ok, response} -> {:error, response.body}
       {:error, %{reason: reason}} -> {:error, reason}
       {:error, error} -> {:error, error}
+    end
+  end
+
+  defp do_post_http(base_address, post_body, req_headers, http_opts, async_opts) do
+    case async_opts[:async] do
+      false ->
+        HTTPoison.post(base_address, post_body, req_headers, http_opts)
+
+      true ->
+        spawn(fn ->
+          response  = HTTPoison.post(base_address, post_body, req_headers, http_opts)
+          maybe_notify(async_opts[:async_callback], response)
+        end)
+        {:async, :executing}
     end
   end
 

--- a/lib/clickhousex/http_client.ex
+++ b/lib/clickhousex/http_client.ex
@@ -11,10 +11,9 @@ defmodule Clickhousex.HTTPClient do
     send_p(query, request, base_address, database, [timeout: timeout, recv_timeout: timeout], [])
   end
 
-  def send(query, request, base_address, timeout, username, password, database, opts) do
-    async = Keyword.get(opts, :async, false)
-    async_callback = Keyword.get(opts, :async_callback)
-    async_opts = [async: async, async_callback: async_callback]
+  def send(query, request, base_address, timeout, username, password, database, opts \\ []) do
+    async_opts = Keyword.take(opts, [:async, :async_callback])
+
 
     local_opts = [
       hackney: [basic_auth: {username, password}],

--- a/lib/clickhousex/protocol.ex
+++ b/lib/clickhousex/protocol.ex
@@ -48,8 +48,7 @@ defmodule Clickhousex.Protocol do
              opts[:timeout],
              opts[:username],
              opts[:password],
-             opts[:database],
-             opts
+             opts[:database]
            ) do
       {:ok, %__MODULE__{conn_opts: opts, base_address: base_address}}
     end

--- a/lib/clickhousex/protocol.ex
+++ b/lib/clickhousex/protocol.ex
@@ -48,7 +48,8 @@ defmodule Clickhousex.Protocol do
              opts[:timeout],
              opts[:username],
              opts[:password],
-             opts[:database]
+             opts[:database],
+             opts
            ) do
       {:ok, %__MODULE__{conn_opts: opts, base_address: base_address}}
     end
@@ -165,15 +166,15 @@ defmodule Clickhousex.Protocol do
 
   ## Private functions
 
-  defp do_query(query, params, _opts, state) do
+  defp do_query(query, params, opts, state) do
     base_address = state.base_address
     username = state.conn_opts[:username]
     password = state.conn_opts[:password]
-    timeout = state.conn_opts[:timeout]
+    timeout = Keyword.get(opts,:timeout, state.conn_opts[:timeout])
     database = state.conn_opts[:database]
 
     query
-    |> Client.send(params, base_address, timeout, username, password, database)
+    |> Client.send(params, base_address, timeout, username, password, database, opts)
     |> wrap_errors()
     |> case do
       {:ok, :selected, columns, rows} ->

--- a/lib/clickhousex/protocol.ex
+++ b/lib/clickhousex/protocol.ex
@@ -166,11 +166,12 @@ defmodule Clickhousex.Protocol do
   ## Private functions
 
   defp do_query(query, params, opts, state) do
-    base_address = state.base_address
-    username = state.conn_opts[:username]
-    password = state.conn_opts[:password]
-    timeout = Keyword.get(opts,:timeout, state.conn_opts[:timeout])
-    database = state.conn_opts[:database]
+
+    %{base_address: base_address, conn_opts: conn_opts} = state
+    username = opts[:username] || conn_opts[:username]
+    password = opts[:password] || conn_opts[:password]
+    timeout = opts[:timeout] || conn_opts[:timeout]
+    database = opts[:database] || conn_opts[:database]
 
     query
     |> Client.send(params, base_address, timeout, username, password, database, opts)


### PR DESCRIPTION
Through this PR we fixed 

- The issue we had before Clickhousex was ignoring the opts values like timeout
- We implemented a new option we can pass it by the Repo, and it is allowing us to execute Clickhouse queries asynchronously
   - Implemented a callback for Aysnc mode
   - An Example of using the new options  
   `Clickhouse.Repo.query('SELECT DISTINCT ("number"*0) AS "Defunct", sleep(3) FROM system.numbers_mt', [], [timeout: 20000, async: true, async_callback: fn x -> IO.inspect(x) end])
   `