### PR TITLE
Use opts on do query

### DIFF
--- a/lib/clickhousex/codec/values.ex
+++ b/lib/clickhousex/codec/values.ex
@@ -1,11 +1,11 @@
 defmodule Clickhousex.Codec.Values do
   alias Clickhousex.Query
 
-  def encode(%Query{param_count: 0, type: :insert}, _, []) do
+  def encode(%Query{param_count: 0, statement: statement, type: :insert}, _, []) do
     # An insert query's arguments go into the post body and the query part goes into the query string.
     # If we don't have any arguments, we don't have to encode anything, but we don't want to return
     # anything here because we'll duplicate the query into both the query string and post body
-    ""
+    statement
   end
 
   def encode(%Query{param_count: 0, statement: statement}, _, []) do

--- a/lib/clickhousex/protocol.ex
+++ b/lib/clickhousex/protocol.ex
@@ -165,12 +165,12 @@ defmodule Clickhousex.Protocol do
 
   ## Private functions
 
-  defp do_query(query, params, _opts, state) do
-    base_address = state.base_address
-    username = state.conn_opts[:username]
-    password = state.conn_opts[:password]
-    timeout = state.conn_opts[:timeout]
-    database = state.conn_opts[:database]
+  defp do_query(query, params, opts, state) do
+    %{base_address: base_address, conn_opts: conn_opts} = state
+    username = opts[:username] || conn_opts[:username]
+    password = opts[:password] || conn_opts[:password]
+    timeout = opts[:timeout] || conn_opts[:timeout]
+    database = opts[:database] || conn_opts[:database]
 
     query
     |> Client.send(params, base_address, timeout, username, password, database)


### PR DESCRIPTION
- make the connection opts able to overwrite by passing them on the query option keyword list

An Example to overwrite the connection timeout

```
Repo.query("SELECT sleep(20)", [], timeout: 300000)
```