### PR TITLE
Move insert query to be in post request

### DIFF
--- a/lib/clickhousex/codec/values.ex
+++ b/lib/clickhousex/codec/values.ex
@@ -1,11 +1,11 @@
 defmodule Clickhousex.Codec.Values do
   alias Clickhousex.Query
 
-  def encode(%Query{param_count: 0, type: :insert}, _, []) do
+  def encode(%Query{param_count: 0, statement: statement, type: :insert}, _, []) do
     # An insert query's arguments go into the post body and the query part goes into the query string.
     # If we don't have any arguments, we don't have to encode anything, but we don't want to return
     # anything here because we'll duplicate the query into both the query string and post body
-    ""
+    statement
   end
 
   def encode(%Query{param_count: 0, statement: statement}, _, []) do


### PR DESCRIPTION
Because of the limitation in the get request in terms of the request size, by this edit, we moved the insert query to be sent as a post request rather than get.