### PR TITLE
Hackney pool

### DIFF
--- a/lib/clickhousex/http_client.ex
+++ b/lib/clickhousex/http_client.ex
@@ -7,12 +7,17 @@ defmodule Clickhousex.HTTPClient do
 
   @req_headers [{"Content-Type", "text/plain"}]
 
-  def send(query, request, base_address, timeout, nil, _password, database) do
+  def send(query, request, base_address, timeout, nil, _password, database, _hackney_pool \\ :default) do
     send_p(query, request, base_address, database, timeout: timeout, recv_timeout: timeout)
   end
 
-  def send(query, request, base_address, timeout, username, password, database) do
-    opts = [hackney: [basic_auth: {username, password}], timeout: timeout, recv_timeout: timeout]
+  def send(query, request, base_address, timeout, username, password, database, hackney_pool) do
+    opts = [
+      hackney: [pool: hackney_pool, basic_auth: {username, password}],
+      timeout: timeout,
+      recv_timeout: timeout
+    ]
+
     send_p(query, request, base_address, database, opts)
   end
 
@@ -22,7 +27,7 @@ defmodule Clickhousex.HTTPClient do
          base_address,
          database,
          opts
-       ) when query_type in [:select, :alter, :update]  do
+       ) when query_type in [:select, :alter, :update] do
     command = parse_command(query)
 
     http_headers =
@@ -44,8 +49,7 @@ defmodule Clickhousex.HTTPClient do
 
   defp send_p(query, request, base_address, database, opts) do
     command = parse_command(query)
-
-    post_body = maybe_append_format(query, request)
+    post_body = append_format(query, request)
 
     http_opts =
       Keyword.put(opts, :params, %{
@@ -87,4 +91,5 @@ defmodule Clickhousex.HTTPClient do
       "X-ClickHouse-Format" => response_format
     })
   end
+
 end

--- a/lib/clickhousex/http_client.ex
+++ b/lib/clickhousex/http_client.ex
@@ -49,7 +49,7 @@ defmodule Clickhousex.HTTPClient do
 
   defp send_p(query, request, base_address, database, opts) do
     command = parse_command(query)
-    post_body = append_format(query, request)
+    post_body = maybe_append_format(query, request)
 
     http_opts =
       Keyword.put(opts, :params, %{

--- a/lib/clickhousex/protocol.ex
+++ b/lib/clickhousex/protocol.ex
@@ -29,7 +29,8 @@ defmodule Clickhousex.Protocol do
     database: "default",
     username: nil,
     password: nil,
-    timeout: Clickhousex.timeout()
+    timeout: Clickhousex.timeout(),
+    hackney_pool: :default
   ]
 
   @impl DBConnection
@@ -48,7 +49,8 @@ defmodule Clickhousex.Protocol do
              opts[:timeout],
              opts[:username],
              opts[:password],
-             opts[:database]
+             opts[:database],
+             opts[:hackney_pool]
            ) do
       {:ok, %__MODULE__{conn_opts: opts, base_address: base_address}}
     end
@@ -171,9 +173,10 @@ defmodule Clickhousex.Protocol do
     password = opts[:password] || conn_opts[:password]
     timeout = opts[:timeout] || conn_opts[:timeout]
     database = opts[:database] || conn_opts[:database]
+    hackney_pool = opts[:hackney_pool] || conn_opts[:hackney_pool]
 
     query
-    |> Client.send(params, base_address, timeout, username, password, database)
+    |> Client.send(params, base_address, timeout, username, password, database, hackney_pool)
     |> wrap_errors()
     |> case do
       {:ok, :selected, columns, rows} ->


### PR DESCRIPTION
Support dedicated(optional) hackney pool.

Any client that wishes this feature can simply pass the pool name in config.

For example:

```
config :core, Core.Clickhouse.Repo,
 hackney_pool: :clickhouse
```

And make sure the pool is started(preferably in app).
Example:

```
defp setup_hackney_clickhouse_pool do
    clickhouse_pool =  [{:max_connections: 150}])
    :hackney_pool.start_pool(:clickhouse, clickhouse_pool)
  end
```